### PR TITLE
chore: bump ubuntu

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -35,7 +35,7 @@ jobs:
 
   go-sec:
     name: Run Gosec
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     env:
       GO111MODULE: on
 


### PR DESCRIPTION
GitHub will be deprecating use of the `ubuntu-20.04` image on April 1st.
